### PR TITLE
Replaced SERNO_STN with visit_key. Functionality to read also dv template.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,12 @@ dependencies = [
     "bokeh==3.3.4",
     "pyproj>=3.6.1",
     "pandas>=2.2.1",
+    "nodc-statistics @ git+https://github.com/nodc-sweden/nodc-statistics@v2024.3.1",
     "sharkadm @ git+https://github.com/nodc-sweden/SHARKadm@v0.5.0",
-    "nodc-statistics @ git+https://github.com/nodc-sweden/nodc-statistics@v0.3.0",
+    "nodc-codes @ git+https://github.com/nodc-sweden/nodc-codes@v0.3.0",
     "ocean-data-qc @ git+https://github.com/nodc-sweden/ocean-data-qc@v2024.6.1",
     "Jinja2>=3.1.3",
-]
+    ]
 requires-python = ">=3.11"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/qc_tool/data_transformation.py
+++ b/src/qc_tool/data_transformation.py
@@ -5,7 +5,6 @@ from ocean_data_qc.fyskem.qc_flag_tuple import QcField
 def prepare_data(data: pd.DataFrame):
     # Create station name with zero padded serial number
     data["SERNO"] = data["SERNO"].map("{:03}".format)
-    data["SERNO_STN"] = data["SERNO"] + " - " + data["STATN"]
 
     # Create the long qc string using "quality_flag" as incoming qc
     if "quality_flag_long" not in data.columns and "quality_flag" in data.columns:

--- a/src/qc_tool/file_handler.py
+++ b/src/qc_tool/file_handler.py
@@ -2,7 +2,6 @@ import tkinter
 import tkinter.filedialog
 from pathlib import Path
 
-import pandas as pd
 import sharkadm
 import sharkadm.data
 from bokeh.models import Button, Column, Div, FileInput
@@ -64,7 +63,9 @@ class FileHandler(Layoutable):
         else:
             self._file_name = selected_path
             self._file_loaded()
-            data = pd.read_csv(selected_path, sep="\t")
+            data = sharkadm.dv_template_data.get_row_data_from_fyschem_dv_template(
+                selected_path
+            )
 
         self._external_load_file_callback(data)
 

--- a/src/qc_tool/main.py
+++ b/src/qc_tool/main.py
@@ -258,12 +258,12 @@ class QcTool:
         self._data = data
 
         # Extract list of all station visits
-        station_series = sorted(data["SERNO_STN"].unique())
+        station_series = sorted(data["visit_key"].unique())
 
         # Initialize all stations
         self._stations = {
             series: Station(
-                series, self._data[self._data["SERNO_STN"] == series], self._geo_info
+                series, self._data[self._data["visit_key"] == series], self._geo_info
             )
             for series in station_series
         }

--- a/tests/test_data_transformation.py
+++ b/tests/test_data_transformation.py
@@ -36,45 +36,6 @@ def test_prepare_data_makes_series_number_zero_padded_string(given_serno, expect
 
 
 @pytest.mark.parametrize(
-    "given_serno, given_station",
-    (
-        (1, "SLÄGGÖ"),
-        (12, "ANHOLT E"),
-        (123, "BY31 LANDSORTSDJ"),
-        (1234, "BY4 CHRISTIANSÖ"),
-    ),
-)
-def test_prepare_data_creates_a_combined_serno_station_field(given_serno, given_station):
-    # Given data where data has a given serial number and station name
-    given_data = pd.DataFrame(
-        (
-            {"STATN": given_station, "SERNO": given_serno},
-            {"STATN": given_station, "SERNO": given_serno},
-            {"STATN": given_station, "SERNO": given_serno},
-        )
-    )
-
-    # Given there is no column named SERNO_STN
-    assert "SERNO_STN" not in given_data.columns
-
-    # When preparing data
-    transformed_data = data_transformation.prepare_data(given_data)
-
-    # Then the column SERNO_STN is added
-    assert "SERNO_STN" in transformed_data.columns
-
-    # And all rows have the same value
-    all_serno_stn = transformed_data["SERNO_STN"].unique()
-    assert len(all_serno_stn) == 1
-
-    # And the value is a combination of the two fields
-    serno_stn = all_serno_stn[0]
-    serno_part, station_part = serno_stn.split("-")
-    assert str(given_serno) in serno_part
-    assert given_station in station_part
-
-
-@pytest.mark.parametrize(
     "given_quality_flag",
     (
         "0",


### PR DESCRIPTION
pyproject.toml should point to main brain of SHARKadm until next release. Newest version of nodc_codes should also be used.