### PR TITLE
Dynamic root directory

### DIFF
--- a/src/qc_tool/scripts/start_server.py
+++ b/src/qc_tool/scripts/start_server.py
@@ -1,5 +1,6 @@
 import argparse
 import subprocess
+from pathlib import Path
 
 
 def main():
@@ -15,7 +16,8 @@ def setup_arguments():
 def start_server():
     try:
         print("Stop server with Ctrl-C")
-        subprocess.run(["bokeh", "serve", "--show", "src/qc_tool"])
+        server_root_directory = Path(__file__).parent.parent
+        subprocess.run(["bokeh", "serve", "--show", str(server_root_directory)])
     except KeyboardInterrupt:
         print("Stopping server")
 


### PR DESCRIPTION
When starting the bokeh server, the root directory must be fouhnd dynamically to mkae sure that it works both while developing and for the end-user.

Fixes #77 