### PR TITLE
Remove use of metadaqc

### DIFF
--- a/src/qc_tool/main.py
+++ b/src/qc_tool/main.py
@@ -265,16 +265,6 @@ class QcTool:
 
         self._set_data(self._data, self._selected_station.visit_key)
 
-    def metadata_qc_callback(self):
-        print("Metadata QC started...")
-        t0 = time.perf_counter()
-        for station in self._stations.values():
-            station.run_metadata_qc()
-        t1 = time.perf_counter()
-        print(f"Metadata QC finished ({t1 - t0:.3f} s.)")
-        self._station_info.update()
-        self._metadata_qc_handler.update()
-
     def manual_qc_callback(self, values: list[Parameter]):
         """ "Called when manual qc has been applied."""
         # Update quality flag in data
@@ -404,7 +394,6 @@ class QcTool:
             for visit_key in station_visit
         }
         self._station_navigator.load_stations(self._stations)
-        self.metadata_qc_callback()
         self._map.load_stations(self._stations)
         self.set_station(station or station_visit[0])
 

--- a/src/qc_tool/station.py
+++ b/src/qc_tool/station.py
@@ -1,6 +1,5 @@
 import polars as pl
 from ocean_data_qc.metadata.visit import Visit
-from ocean_data_qc.metadataqc import MetadataQc
 
 
 class Station:
@@ -43,10 +42,6 @@ class Station:
             self._sea_basin = None
 
         self._visit = Visit(self.data)
-
-    def run_metadata_qc(self):
-        metadata_qc = MetadataQc(self._visit)
-        metadata_qc.run_qc()
 
     @property
     def parameters(self) -> list[str]:


### PR DESCRIPTION
There is still a connection to e.g. the Visit class that potentially can be moved to qc-tool.

Part of #128